### PR TITLE
Prepare geolibre 0.1.0 for CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,5 +3,6 @@
 ^README\.Rmd$
 ^\.gitignore$
 ^LICENSE\.md$
+^cran-comments\.md$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,15 @@
 Package: geolibre
 Title: Interactive GIS with 'GeoLibre'
-Version: 0.1.0.9000
-Authors@R: person("Qiusheng", "Wu", email = "giswqs@gmail.com", role = c("aut", "cre"))
-Description: Embeds the full 'GeoLibre' geographic information system in R
-    Markdown, 'Quarto', 'Shiny', and the RStudio Viewer. Create maps from
+Version: 0.1.0
+Authors@R: c(
+    person("Qiusheng", "Wu", email = "giswqs@gmail.com", role = c("aut", "cre")),
+    person("Open Geospatial Solutions", role = "cph")
+    )
+Description: Embeds the full 'GeoLibre' geographic information system in
+    'R Markdown', 'Quarto', 'Shiny', and the 'RStudio' Viewer. Create maps from
     'GeoJSON' and 'sf' objects, add remote raster sources, control the camera,
-    and read and write '.geolibre.json' project files.
+    and read and write '.geolibre.json' project files. The underlying
+    application is described in Wu (2026) <doi:10.5281/zenodo.20785400>.
 License: MIT + file LICENSE
 URL: https://github.com/opengeos/geolibre-r, https://geolibre.app
 BugReports: https://github.com/opengeos/geolibre-r/issues
@@ -14,11 +18,11 @@ Imports:
     htmlwidgets,
     jsonlite
 Suggests:
-    htmltools,
     sf,
     shiny,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
+Language: en-US
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+# geolibre 0.1.0
+
+Initial CRAN release.
+
+- Add a responsive `htmlwidgets` interface to GeoLibre for RStudio, Quarto,
+  R Markdown, and Shiny.
+- Add GeoJSON and `sf` vector layers and remote COG/GeoTIFF raster layers.
+- Add camera controls and `.geolibre.json` project import and export.
+- Add Shiny output, render, proxy, and live project-state bindings.
+- Support hosted and self-hosted GeoLibre deployments.

--- a/R/geolibre.R
+++ b/R/geolibre.R
@@ -7,11 +7,22 @@
 #'   `?embed=1` project bridge.
 #' @param map_only Hide the application chrome and show only the map.
 #' @param elementId Optional widget element ID.
+#' @details The default hosted application requires internet access when the
+#'   widget is displayed. Package installation, project construction, and file
+#'   operations do not contact it. Set `app_url` or the `geolibre.app_url`
+#'   option to use a self-hosted deployment.
 #' @return An `htmlwidget` that can be modified with `add_*()` functions.
+#' @examples
+#' map <- geolibre(map_only = TRUE)
+#' stopifnot(inherits(map, "geolibre"))
 #' @export
 geolibre <- function(project = NULL, width = NULL, height = NULL,
                      app_url = getOption("geolibre.app_url", "https://web.geolibre.app/"),
                      map_only = FALSE, elementId = NULL) {
+  if (!is.character(app_url) || length(app_url) != 1L || is.na(app_url) ||
+      !grepl("^https?://", app_url)) {
+    stop("`app_url` must be a single HTTP(S) URL.", call. = FALSE)
+  }
   project <- normalize_project(project)
   htmlwidgets::createWidget(
     name = "geolibre",
@@ -53,7 +64,15 @@ normalize_project <- function(project) {
   required <- c("version", "name", "mapView")
   missing <- setdiff(required, names(project))
   if (length(missing)) stop("Invalid project; missing: ", paste(missing, collapse = ", "), call. = FALSE)
+  if (!is.character(project$version) || length(project$version) != 1L || is.na(project$version)) {
+    stop("Invalid project; `version` must be a single string.", call. = FALSE)
+  }
+  if (!is.character(project$name) || length(project$name) != 1L || is.na(project$name)) {
+    stop("Invalid project; `name` must be a single string.", call. = FALSE)
+  }
+  if (!is.list(project$mapView)) stop("Invalid project; `mapView` must be a list.", call. = FALSE)
   if (is.null(project$layers)) project$layers <- list()
+  if (!is.list(project$layers)) stop("Invalid project; `layers` must be a list.", call. = FALSE)
   project
 }
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -8,9 +8,18 @@
 #' @param visible Whether the layer is initially visible.
 #' @param opacity Layer opacity from zero to one.
 #' @return The modified widget.
+#' @examples
+#' point <- list(
+#'   type = "Feature",
+#'   properties = list(name = "Washington, DC"),
+#'   geometry = list(type = "Point", coordinates = c(-77.0369, 38.9072))
+#' )
+#' map <- geolibre() |> add_geojson(point, name = "Places")
+#' stopifnot(length(map$x$project$layers) == 1L)
 #' @export
 add_geojson <- function(map, data, name = "GeoJSON", style = list(),
                         visible = TRUE, opacity = 1) {
+  validate_layer_options(name, style, visible)
   project <- widget_project(map)
   geojson <- as_geojson(data)
   layer <- list(
@@ -30,6 +39,14 @@ add_geojson <- function(map, data, name = "GeoJSON", style = list(),
 #' @param data An `sf` or `sfc` object.
 #' @inheritParams add_geojson
 #' @return The modified widget.
+#' @examples
+#' if (requireNamespace("sf", quietly = TRUE)) {
+#'   point <- sf::st_sf(
+#'     name = "Washington, DC",
+#'     geometry = sf::st_sfc(sf::st_point(c(-77.0369, 38.9072)), crs = 4326)
+#'   )
+#'   map <- geolibre() |> add_sf(point, name = "Places")
+#' }
 #' @export
 add_sf <- function(map, data, name = deparse(substitute(data)), style = list(),
                    visible = TRUE, opacity = 1) {
@@ -53,12 +70,21 @@ add_sf <- function(map, data, name = deparse(substitute(data)), style = list(),
 #' @param visible Whether the layer is visible.
 #' @param opacity Layer opacity from zero to one.
 #' @return The modified widget.
+#' @examples
+#' map <- geolibre() |>
+#'   add_raster("https://example.com/image.tif", bands = c(1, 2, 3))
+#' stopifnot(map$x$project$layers[[1]]$type == "cog")
 #' @export
 add_raster <- function(map, url, name = "Raster", bands = NULL,
                        colormap = NULL, rescale = NULL, style = list(),
                        visible = TRUE, opacity = 1) {
-  if (!is.character(url) || length(url) != 1L || !grepl("^https?://", url)) {
+  validate_layer_options(name, style, visible)
+  if (!is.character(url) || length(url) != 1L || is.na(url) || !grepl("^https?://", url)) {
     stop("`url` must be a single public HTTP(S) URL.", call. = FALSE)
+  }
+  if (!is.null(colormap) &&
+      (!is.character(colormap) || length(colormap) != 1L || is.na(colormap))) {
+    stop("`colormap` must be NULL or a single string.", call. = FALSE)
   }
   if (!is.null(bands) &&
       (!is.numeric(bands) || !length(bands) || any(!is.finite(bands)) ||
@@ -109,14 +135,39 @@ as_geojson <- function(data) {
     path <- tempfile(fileext = ".geojson")
     on.exit(unlink(path), add = TRUE)
     sf::st_write(data, path, driver = "GeoJSON", quiet = TRUE)
-    return(jsonlite::read_json(path, simplifyVector = FALSE))
+    data <- jsonlite::read_json(path, simplifyVector = FALSE)
   }
   if (is.character(data) && length(data) == 1L) {
     text <- if (file.exists(data)) paste(readLines(data, warn = FALSE), collapse = "\n") else data
-    return(jsonlite::fromJSON(text, simplifyVector = FALSE))
+    data <- tryCatch(
+      jsonlite::fromJSON(text, simplifyVector = FALSE),
+      error = function(error) stop("`data` is not valid GeoJSON: ", conditionMessage(error), call. = FALSE)
+    )
   }
   if (!is.list(data)) stop("`data` must be GeoJSON, a path, JSON, or an sf object.", call. = FALSE)
-  data
+  type <- data$type
+  if (!is.character(type) || length(type) != 1L) {
+    stop("GeoJSON must have a single string `type`.", call. = FALSE)
+  }
+  if (identical(type, "FeatureCollection")) {
+    if (is.null(data$features)) data$features <- list()
+    if (!is.list(data$features)) stop("A GeoJSON FeatureCollection must contain a `features` list.", call. = FALSE)
+    return(data)
+  }
+  if (identical(type, "Feature")) {
+    return(list(type = "FeatureCollection", features = list(data)))
+  }
+  geometry_types <- c(
+    "Point", "MultiPoint", "LineString", "MultiLineString",
+    "Polygon", "MultiPolygon", "GeometryCollection"
+  )
+  if (type %in% geometry_types) {
+    return(list(
+      type = "FeatureCollection",
+      features = list(list(type = "Feature", properties = list(), geometry = data))
+    ))
+  }
+  stop("Unsupported GeoJSON type: ", type, call. = FALSE)
 }
 
 validate_opacity <- function(value) {
@@ -124,4 +175,18 @@ validate_opacity <- function(value) {
     stop("`opacity` must be a number between 0 and 1.", call. = FALSE)
   }
   unname(value)
+}
+
+validate_layer_options <- function(name, style, visible) {
+  if (!is.character(name) || length(name) != 1L || is.na(name) || !nzchar(name)) {
+    stop("`name` must be a single non-empty string.", call. = FALSE)
+  }
+  if (!is.list(style)) stop("`style` must be a named list.", call. = FALSE)
+  if (length(style) && (is.null(names(style)) || any(!nzchar(names(style))))) {
+    stop("`style` must be a named list.", call. = FALSE)
+  }
+  if (!is.logical(visible) || length(visible) != 1L || is.na(visible)) {
+    stop("`visible` must be TRUE or FALSE.", call. = FALSE)
+  }
+  invisible(TRUE)
 }

--- a/R/project.R
+++ b/R/project.R
@@ -2,13 +2,22 @@
 #'
 #' @param source Path to a `.geolibre.json` file or a JSON string.
 #' @return A project list.
+#' @examples
+#' project <- load_project('{"version":"0.2.0","name":"Example","mapView":{}}')
+#' stopifnot(project$name == "Example")
 #' @export
 load_project <- function(source) {
   if (!is.character(source) || length(source) != 1L) stop("`source` must be a path or JSON string.", call. = FALSE)
   project <- if (file.exists(source)) {
     jsonlite::read_json(source, simplifyVector = FALSE)
   } else {
-    jsonlite::fromJSON(source, simplifyVector = FALSE)
+    tryCatch(
+      jsonlite::fromJSON(source, simplifyVector = FALSE),
+      error = function(error) {
+        stop("`source` is neither an existing file nor valid project JSON: ",
+             conditionMessage(error), call. = FALSE)
+      }
+    )
   }
   normalize_project(project)
 }
@@ -18,8 +27,16 @@ load_project <- function(source) {
 #' @param map A GeoLibre widget or project list.
 #' @param path Output path, conventionally ending in `.geolibre.json`.
 #' @return `path`, invisibly.
+#' @examples
+#' path <- tempfile(fileext = ".geolibre.json")
+#' save_project(geolibre(), path)
+#' project <- load_project(path)
+#' stopifnot(project$name == "Untitled Project")
 #' @export
 save_project <- function(map, path) {
+  if (!is.character(path) || length(path) != 1L || is.na(path) || !nzchar(path)) {
+    stop("`path` must be a single non-empty string.", call. = FALSE)
+  }
   project <- if (inherits(map, "geolibre")) widget_project(map) else normalize_project(map)
   dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
   jsonlite::write_json(project, path, pretty = TRUE, auto_unbox = TRUE, null = "null", digits = NA)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2,8 +2,14 @@
 #'
 #' @param outputId Output variable to read from.
 #' @param width,height Widget dimensions.
+#' @examples
+#' if (requireNamespace("shiny", quietly = TRUE)) {
+#'   output <- geolibreOutput("map", height = "500px")
+#'   stopifnot(inherits(output, "shiny.tag.list"))
+#' }
 #' @export
 geolibreOutput <- function(outputId, width = "100%", height = "700px") {
+  require_suggested("shiny", "geolibreOutput()")
   htmlwidgets::shinyWidgetOutput(outputId, "geolibre", width, height, package = "geolibre")
 }
 
@@ -13,6 +19,7 @@ geolibreOutput <- function(outputId, width = "100%", height = "700px") {
 #' @rdname geolibreOutput
 #' @export
 renderGeolibre <- function(expr, env = parent.frame(), quoted = FALSE) {
+  require_suggested("shiny", "renderGeolibre()")
   if (!quoted) expr <- substitute(expr)
   htmlwidgets::shinyRenderWidget(expr, geolibreOutput, env, quoted = TRUE)
 }
@@ -22,11 +29,22 @@ renderGeolibre <- function(expr, env = parent.frame(), quoted = FALSE) {
 #' @param outputId ID of an existing GeoLibre widget.
 #' @param session A Shiny session.
 #' @return A proxy object.
+#' @examples
+#' if (interactive() && requireNamespace("shiny", quietly = TRUE)) {
+#'   proxy <- geolibre_proxy("map")
+#' }
 #' @export
-geolibre_proxy <- function(outputId, session = shiny::getDefaultReactiveDomain()) {
-  if (!requireNamespace("shiny", quietly = TRUE)) stop("Package `shiny` is required.", call. = FALSE)
+geolibre_proxy <- function(outputId, session = NULL) {
+  require_suggested("shiny", "geolibre_proxy()")
+  if (is.null(session)) session <- shiny::getDefaultReactiveDomain()
   if (is.null(session)) stop("`session` must be provided outside a reactive context.", call. = FALSE)
   structure(list(id = session$ns(outputId), session = session), class = "geolibre_proxy")
+}
+
+require_suggested <- function(package, caller) {
+  if (!requireNamespace(package, quietly = TRUE)) {
+    stop("Package `", package, "` is required by ", caller, ".", call. = FALSE)
+  }
 }
 
 #' Replace the project displayed by a GeoLibre Shiny widget
@@ -34,6 +52,10 @@ geolibre_proxy <- function(outputId, session = shiny::getDefaultReactiveDomain()
 #' @param proxy A GeoLibre proxy created by `geolibre_proxy()`.
 #' @param map A GeoLibre widget or project list.
 #' @return The proxy, invisibly.
+#' @examples
+#' if (interactive() && requireNamespace("shiny", quietly = TRUE)) {
+#'   update_geolibre(geolibre_proxy("map"), geolibre())
+#' }
 #' @export
 update_geolibre <- function(proxy, map) {
   if (!inherits(proxy, "geolibre_proxy")) stop("`proxy` must be a GeoLibre proxy.", call. = FALSE)

--- a/R/view.R
+++ b/R/view.R
@@ -6,6 +6,10 @@
 #' @param bbox Optional west/south/east/north bounds. When supplied it takes
 #'   precedence over `center` and `zoom`.
 #' @return The modified widget.
+#' @examples
+#' map <- geolibre() |>
+#'   set_view(center = c(-77.0369, 38.9072), zoom = 10, pitch = 30)
+#' stopifnot(map$x$project$mapView$zoom == 10)
 #' @export
 set_view <- function(map, center = NULL, zoom = NULL, bearing = NULL,
                      pitch = NULL, bbox = NULL) {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ GeoLibre's project format and embed bridge.
 ## Installation
 
 ```r
-# install.packages("pak")
+# Once released on CRAN:
+install.packages("geolibre")
+
+# Development version:
+install.packages("pak")
 pak::pak("opengeos/geolibre-r")
 ```
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,25 @@
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+The note is the standard note for a first submission:
+
+```text
+New submission
+```
+
+Tested on:
+
+- local CachyOS Linux, R 4.6.1
+- GitHub Actions: Ubuntu (R-devel, R-release, R-oldrel-1)
+- GitHub Actions: macOS (R-release)
+- GitHub Actions: Windows (R-release)
+
+## New submission
+
+This is the first submission of `geolibre`.
+
+The widget loads the GeoLibre application from `https://web.geolibre.app/` by
+default when displayed. Installation, examples, tests, and R CMD check do not
+contact that service. Users can configure a self-hosted deployment with the
+`app_url` argument or the `geolibre.app_url` option.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,10 @@
+citHeader("To cite GeoLibre in publications, use:")
+
+bibentry(
+  bibtype = "Manual",
+  title = "GeoLibre: A Lightweight, Cloud-Native GIS Platform for Visualizing, Exploring, and Analyzing Geospatial Data",
+  author = person("Qiusheng", "Wu"),
+  year = "2026",
+  doi = "10.5281/zenodo.20785400",
+  url = "https://geolibre.app"
+)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,0 +1,13 @@
+CMD
+CORS
+EPSG
+GeoJSON
+GeoLibre
+GeoLibre's
+GeoTIFF
+GeoTIFFs
+RStudio
+colormap
+doi
+json
+zenodo

--- a/man/add_geojson.Rd
+++ b/man/add_geojson.Rd
@@ -33,3 +33,12 @@ The modified widget.
 \description{
 Add GeoJSON to a GeoLibre map
 }
+\examples{
+point <- list(
+  type = "Feature",
+  properties = list(name = "Washington, DC"),
+  geometry = list(type = "Point", coordinates = c(-77.0369, 38.9072))
+)
+map <- geolibre() |> add_geojson(point, name = "Places")
+stopifnot(length(map$x$project$layers) == 1L)
+}

--- a/man/add_raster.Rd
+++ b/man/add_raster.Rd
@@ -41,3 +41,8 @@ The modified widget.
 \description{
 Add a remote raster to a GeoLibre map
 }
+\examples{
+map <- geolibre() |>
+  add_raster("https://example.com/image.tif", bands = c(1, 2, 3))
+stopifnot(map$x$project$layers[[1]]$type == "cog")
+}

--- a/man/add_sf.Rd
+++ b/man/add_sf.Rd
@@ -33,3 +33,12 @@ The modified widget.
 \description{
 The object is transformed to EPSG:4326 before serialization.
 }
+\examples{
+if (requireNamespace("sf", quietly = TRUE)) {
+  point <- sf::st_sf(
+    name = "Washington, DC",
+    geometry = sf::st_sfc(sf::st_point(c(-77.0369, 38.9072)), crs = 4326)
+  )
+  map <- geolibre() |> add_sf(point, name = "Places")
+}
+}

--- a/man/geolibre.Rd
+++ b/man/geolibre.Rd
@@ -32,3 +32,13 @@ An \code{htmlwidget} that can be modified with \verb{add_*()} functions.
 \description{
 Create a GeoLibre widget
 }
+\details{
+The default hosted application requires internet access when the
+widget is displayed. Package installation, project construction, and file
+operations do not contact it. Set \code{app_url} or the \code{geolibre.app_url}
+option to use a self-hosted deployment.
+}
+\examples{
+map <- geolibre(map_only = TRUE)
+stopifnot(inherits(map, "geolibre"))
+}

--- a/man/geolibreOutput.Rd
+++ b/man/geolibreOutput.Rd
@@ -23,3 +23,9 @@ renderGeolibre(expr, env = parent.frame(), quoted = FALSE)
 \description{
 Shiny bindings for GeoLibre
 }
+\examples{
+if (requireNamespace("shiny", quietly = TRUE)) {
+  output <- geolibreOutput("map", height = "500px")
+  stopifnot(inherits(output, "shiny.tag.list"))
+}
+}

--- a/man/geolibre_proxy.Rd
+++ b/man/geolibre_proxy.Rd
@@ -4,7 +4,7 @@
 \alias{geolibre_proxy}
 \title{Create a GeoLibre Shiny proxy}
 \usage{
-geolibre_proxy(outputId, session = shiny::getDefaultReactiveDomain())
+geolibre_proxy(outputId, session = NULL)
 }
 \arguments{
 \item{outputId}{ID of an existing GeoLibre widget.}
@@ -16,4 +16,9 @@ A proxy object.
 }
 \description{
 Create a GeoLibre Shiny proxy
+}
+\examples{
+if (interactive() && requireNamespace("shiny", quietly = TRUE)) {
+  proxy <- geolibre_proxy("map")
+}
 }

--- a/man/load_project.Rd
+++ b/man/load_project.Rd
@@ -15,3 +15,7 @@ A project list.
 \description{
 Read a GeoLibre project
 }
+\examples{
+project <- load_project('{"version":"0.2.0","name":"Example","mapView":{}}')
+stopifnot(project$name == "Example")
+}

--- a/man/save_project.Rd
+++ b/man/save_project.Rd
@@ -17,3 +17,9 @@ save_project(map, path)
 \description{
 Save a GeoLibre project
 }
+\examples{
+path <- tempfile(fileext = ".geolibre.json")
+save_project(geolibre(), path)
+project <- load_project(path)
+stopifnot(project$name == "Untitled Project")
+}

--- a/man/set_view.Rd
+++ b/man/set_view.Rd
@@ -29,3 +29,8 @@ The modified widget.
 \description{
 Set the GeoLibre camera
 }
+\examples{
+map <- geolibre() |>
+  set_view(center = c(-77.0369, 38.9072), zoom = 10, pitch = 30)
+stopifnot(map$x$project$mapView$zoom == 10)
+}

--- a/man/update_geolibre.Rd
+++ b/man/update_geolibre.Rd
@@ -17,3 +17,8 @@ The proxy, invisibly.
 \description{
 Replace the project displayed by a GeoLibre Shiny widget
 }
+\examples{
+if (interactive() && requireNamespace("shiny", quietly = TRUE)) {
+  update_geolibre(geolibre_proxy("map"), geolibre())
+}
+}

--- a/tests/testthat/test-widget.R
+++ b/tests/testthat/test-widget.R
@@ -25,6 +25,20 @@ test_that("GeoJSON and raster layers are appended", {
   expect_equal(map$x$project$layers[[2]]$metadata$rasterState$mode, "rgb")
 })
 
+test_that("features and geometries are normalized to feature collections", {
+  feature <- list(
+    type = "Feature", properties = list(name = "A"),
+    geometry = list(type = "Point", coordinates = c(-77, 39))
+  )
+  feature_map <- add_geojson(geolibre(), feature)
+  expect_equal(feature_map$x$project$layers[[1]]$geojson$type, "FeatureCollection")
+  expect_length(feature_map$x$project$layers[[1]]$geojson$features, 1)
+
+  geometry_map <- add_geojson(geolibre(), feature$geometry)
+  expect_equal(geometry_map$x$project$layers[[1]]$geojson$features[[1]]$geometry$type, "Point")
+  expect_error(add_geojson(geolibre(), list(type = "Invalid")), "Unsupported")
+})
+
 test_that("view and project JSON round trip", {
   map <- set_view(geolibre(), center = c(-76.5, 38.9), zoom = 9, pitch = 30)
   path <- tempfile(fileext = ".geolibre.json")
@@ -48,6 +62,33 @@ test_that("invalid inputs fail early", {
   expect_error(set_view(geolibre(), zoom = c(1, 2)), "zoom")
   expect_error(set_view(geolibre(), bearing = NA_real_), "bearing")
   expect_error(set_view(geolibre(), pitch = "30"), "pitch")
+  expect_error(geolibre(app_url = "not-a-url"), "HTTP")
+  expect_error(geolibre(list(version = 1, name = "Bad", mapView = list())), "version")
+  expect_error(geolibre(list(version = "0.2.0", name = "Bad", mapView = 1)), "mapView")
+  expect_error(add_geojson(geolibre(), list(type = "FeatureCollection"), name = ""), "name")
+  expect_error(add_geojson(geolibre(), list(type = "FeatureCollection"), style = "red"), "style")
+  expect_error(add_geojson(geolibre(), list(type = "FeatureCollection"), visible = NA), "visible")
+  expect_error(add_raster(geolibre(), NA_character_), "HTTP")
+  expect_error(add_raster(geolibre(), "https://example.com/a.tif", colormap = 1), "colormap")
+  expect_error(load_project("not JSON"), "neither")
+  expect_error(save_project(geolibre(), ""), "path")
+})
+
+test_that("Shiny proxies send complete project updates", {
+  skip_if_not_installed("shiny")
+  messages <- new.env(parent = emptyenv())
+  session <- list(
+    ns = function(id) paste0("ns-", id),
+    sendCustomMessage = function(type, message) {
+      messages$type <- type
+      messages$message <- message
+    }
+  )
+  proxy <- geolibre_proxy("map", session = session)
+  expect_equal(proxy$id, "ns-map")
+  expect_invisible(update_geolibre(proxy, geolibre()))
+  expect_equal(messages$type, "geolibre:update")
+  expect_equal(messages$message$project$name, "Untitled Project")
 })
 
 test_that("sf objects become WGS84 GeoJSON", {


### PR DESCRIPTION
## Summary

- set the first release version to `0.1.0` and add CRAN-ready author, license, language, DOI, citation, NEWS, spelling, and submission metadata
- add offline runnable examples and document the hosted-app network behavior and self-hosting option
- normalize GeoJSON Feature and geometry inputs and tighten project, layer, raster, URL, path, and optional-dependency validation
- expand regression coverage, including Shiny proxy project updates

## Validation

- `R CMD check --as-cran --no-manual geolibre_0.1.0.tar.gz`: 0 errors, 0 warnings, 1 expected `New submission` note
- `devtools::test()`: 45 expectations passed
- `devtools::release_checks()`: passed
- `spelling::spell_check_package()`: no spelling errors
- `urlchecker::url_check()`: all URLs valid
- all examples run offline without launching a browser
- source archive is 12 KB and excludes repository-only submission files

## Remaining before submission

- let the PR matrix validate R-devel, R-release, and R-oldrel on Linux, macOS, and Windows
- optionally run win-builder/R-hub, then upload through the CRAN submission form

The package name `geolibre` is currently available on CRAN.