### PR TITLE
Configure r.geolibre.app for pkgdown

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,5 +4,7 @@
 ^\.gitignore$
 ^LICENSE\.md$
 ^cran-comments\.md$
+^CNAME$
+^docs$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,6 +31,8 @@ jobs:
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)
         shell: Rscript {0}
+      - name: Add custom domain
+        run: cp CNAME docs/CNAME
       - name: Upload site
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+r.geolibre.app

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Description: Embeds the full 'GeoLibre' geographic information system in
     and read and write '.geolibre.json' project files. The underlying
     application is described in Wu (2026) <doi:10.5281/zenodo.20785400>.
 License: MIT + file LICENSE
-URL: https://github.com/opengeos/geolibre-r, https://geolibre.app
+URL: https://r.geolibre.app, https://github.com/opengeos/geolibre-r,
+    https://geolibre.app
 BugReports: https://github.com/opengeos/geolibre-r/issues
 Depends: R (>= 4.1.0)
 Imports:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://opengeos.github.io/geolibre-r/
+url: https://r.geolibre.app/
 template:
   bootstrap: 5
 reference:


### PR DESCRIPTION
## Summary

- add a repository-level `CNAME` for `r.geolibre.app`
- copy the CNAME into every clean pkgdown deployment
- update pkgdown canonical links and package metadata to the custom domain
- exclude the repository CNAME and generated `docs/` tree from CRAN source archives

## Validation

- DNS already resolves `r.geolibre.app` to `opengeos.github.io`
- local pkgdown build reports all metadata URLs valid and generates `https://r.geolibre.app` sitemap URLs
- built source tarball excludes both `CNAME` and `docs/`
- `R CMD check --no-manual`: 0 errors, 0 warnings, 0 notes
- workflow and pkgdown YAML parse successfully

After merge, the pkgdown workflow will publish the CNAME to `gh-pages`; GitHub Pages can then provision the TLS certificate for the custom hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the package website address to `https://r.geolibre.app/`.
  * Added the custom domain to package metadata and website deployment settings.
* **Chores**
  * Preserved the custom domain during documentation builds.
  * Excluded website files from package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->