### PR TITLE
Add interactive map to pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,5 +6,6 @@
 ^cran-comments\.md$
 ^CNAME$
 ^docs$
+^vignettes/articles$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,17 +28,17 @@ jobs:
     env:
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
-      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: any::rcmdcheck
           needs: check
-      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -17,14 +17,14 @@ jobs:
       group: pkgdown-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
-      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: any::pkgdown
           needs: website
@@ -34,7 +34,7 @@ jobs:
       - name: Add custom domain
         run: cp CNAME docs/CNAME
       - name: Upload site
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pkgdown-site
           path: docs
@@ -46,16 +46,16 @@ jobs:
       # Required only here so the deployment action can update gh-pages.
       contents: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Download site
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pkgdown-site
           path: docs
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           folder: docs
           branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 RStudio, Quarto, R Markdown, and Shiny. It is an `htmlwidgets` interface to
 GeoLibre's project format and embed bridge.
 
+[Open the live interactive map example](https://r.geolibre.app/articles/interactive-map.html)
+to try the R widget directly in your browser.
+
 ## Installation
 
 ```r

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,17 @@
 url: https://r.geolibre.app/
 template:
   bootstrap: 5
+navbar:
+  structure:
+    left: [intro, reference, articles, news]
+  components:
+    articles:
+      text: Interactive map
+      href: articles/interactive-map.html
+articles:
+  - title: Interactive examples
+    contents:
+      - articles/interactive-map
 reference:
   - title: Create maps
     contents: [geolibre, add_geojson, add_sf, add_raster, set_view]

--- a/vignettes/articles/interactive-map.Rmd
+++ b/vignettes/articles/interactive-map.Rmd
@@ -1,0 +1,35 @@
+---
+title: "Interactive GeoLibre map"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+This page runs the same `geolibre` code used in RStudio, Quarto, R Markdown,
+and Shiny. The widget below embeds the hosted GeoLibre application, so viewing
+the live map requires JavaScript and internet access.
+
+```{r interactive-map}
+library(geolibre)
+
+point <- list(
+  type = "Feature",
+  properties = list(name = "Washington, DC"),
+  geometry = list(
+    type = "Point",
+    coordinates = c(-77.0369, 38.9072)
+  )
+)
+
+geolibre(map_only = TRUE, height = 600) |>
+  add_geojson(
+    point,
+    name = "Washington, DC",
+    style = list(fillColor = "#dc2626", circleRadius = 8)
+  ) |>
+  set_view(center = c(-77.0369, 38.9072), zoom = 10)
+```
+
+If the embedded application is unavailable, open
+[GeoLibre Web](https://web.geolibre.app/) directly.


### PR DESCRIPTION
## Summary

- add a website-only pkgdown article containing a live GeoLibre map
- link the interactive example from the homepage and navigation
- exclude the article from the CRAN source package
- update GitHub Actions to their latest stable releases, pinned to immutable SHAs

## Validation

- `pkgdown::build_site(new_process = FALSE, install = TRUE)`
- 45 package tests pass
- `R CMD check --no-manual geolibre_0.1.0.tar.gz` — Status: OK
- verified website-only files are absent from the CRAN tarball