### PR TITLE
feat: add a panels argument to control side-panel state

### DIFF
--- a/R/geolibre.R
+++ b/R/geolibre.R
@@ -19,6 +19,8 @@
 #' @param theme Application theme, `"light"` or `"dark"`.
 #' @param map_only Deprecated. `TRUE` is equivalent to `layout = "maponly"`.
 #' @param elementId Optional widget element ID.
+#' @param panels Initial side-panel state: `"expanded"`, `"collapsed"` (icon
+#'   rails remain available), or `"hidden"`.
 #' @details The default hosted application requires internet access when the
 #'   widget is displayed. Package installation, project construction, and file
 #'   operations do not contact it. Set `app_url` or the `geolibre.app_url`
@@ -36,7 +38,8 @@ geolibre <- function(project = NULL, center = NULL, zoom = NULL, basemap = NULL,
                      name = "Untitled Project", width = NULL, height = NULL,
                      app_url = getOption("geolibre.app_url", "https://web.geolibre.app/"),
                      layout = c("embed", "full", "maponly"), theme = c("light", "dark"),
-                     map_only = FALSE, elementId = NULL) {
+                     map_only = FALSE, elementId = NULL,
+                     panels = c("expanded", "collapsed", "hidden")) {
   check_http_url(app_url, "app_url")
   layout <- if (missing(layout)) {
     if (isTRUE(map_only)) "maponly" else "embed"
@@ -44,6 +47,7 @@ geolibre <- function(project = NULL, center = NULL, zoom = NULL, basemap = NULL,
     check_choice(match.arg(layout), c("embed", "full", "maponly"), "layout")
   }
   theme <- check_choice(match.arg(theme), c("light", "dark"), "theme")
+  panels <- check_choice(match.arg(panels), c("expanded", "collapsed", "hidden"), "panels")
   project <- if (is.null(project)) {
     new_project(
       name = name,
@@ -60,7 +64,8 @@ geolibre <- function(project = NULL, center = NULL, zoom = NULL, basemap = NULL,
       project = project,
       appUrl = app_url,
       layout = layout,
-      theme = theme
+      theme = theme,
+      panels = panels
     ),
     width = width,
     height = height,

--- a/inst/htmlwidgets/geolibre.js
+++ b/inst/htmlwidgets/geolibre.js
@@ -9,6 +9,8 @@
     const url = new URL(base, window.location.href);
     url.searchParams.set("embed", "1");
     if (theme) url.searchParams.set("theme", theme);
+    // A self-hosted `app_url` may already carry `panels`; the argument wins.
+    url.searchParams.delete("panels");
     if (panels === "collapsed") url.searchParams.set("panels", "collapsed");
     if (panels === "hidden") url.searchParams.set("panels", "none");
     if (layout === "maponly") {

--- a/inst/htmlwidgets/geolibre.js
+++ b/inst/htmlwidgets/geolibre.js
@@ -4,11 +4,13 @@
   const instances = new Map();
 
   // Build the embed URL. `embed=1` turns on the project bridge the widget speaks;
-  // `layout` and `theme` select the application chrome.
-  function embedUrl(base, layout, theme) {
+  // `layout`, `theme`, and `panels` select the application chrome.
+  function embedUrl(base, layout, theme, panels) {
     const url = new URL(base, window.location.href);
     url.searchParams.set("embed", "1");
     if (theme) url.searchParams.set("theme", theme);
+    if (panels === "collapsed") url.searchParams.set("panels", "collapsed");
+    if (panels === "hidden") url.searchParams.set("panels", "none");
     if (layout === "maponly") {
       url.searchParams.set("maponly", "1");
     } else if (layout !== "full") {
@@ -23,7 +25,7 @@
     iframe.title = "GeoLibre interactive map";
     iframe.allow = "fullscreen; clipboard-read; clipboard-write; geolocation";
     iframe.allowFullscreen = true;
-    iframe.src = embedUrl(x.appUrl, x.layout, x.theme);
+    iframe.src = embedUrl(x.appUrl, x.layout, x.theme, x.panels);
     el.replaceChildren(iframe);
     return iframe;
   }
@@ -134,7 +136,7 @@
       const instance = {
         renderValue: function (x) {
           project = x.project;
-          const signature = [x.appUrl, x.layout, x.theme].join("|");
+          const signature = [x.appUrl, x.layout, x.theme, x.panels].join("|");
           if (!iframe || iframe.dataset.signature !== signature) {
             ready = false;
             pendingCommands.length = 0;

--- a/man/geolibre.Rd
+++ b/man/geolibre.Rd
@@ -16,7 +16,8 @@ geolibre(
   layout = c("embed", "full", "maponly"),
   theme = c("light", "dark"),
   map_only = FALSE,
-  elementId = NULL
+  elementId = NULL,
+  panels = c("expanded", "collapsed", "hidden")
 )
 }
 \arguments{
@@ -45,6 +46,9 @@ JSON URL. Ignored when \code{project} is supplied, which carries its own.}
 \item{map_only}{Deprecated. \code{TRUE} is equivalent to \code{layout = "maponly"}.}
 
 \item{elementId}{Optional widget element ID.}
+
+\item{panels}{Initial side-panel state: \code{"expanded"}, \code{"collapsed"} (icon
+rails remain available), or \code{"hidden"}.}
 }
 \value{
 An \code{htmlwidget} that can be modified with \verb{add_*()} functions.

--- a/tests/testthat/test-widget.R
+++ b/tests/testthat/test-widget.R
@@ -116,12 +116,16 @@ test_that("the constructor seeds the camera, basemap, and name", {
 test_that("layout and theme reach the widget payload", {
   expect_equal(geolibre()$x$layout, "embed")
   expect_equal(geolibre()$x$theme, "light")
+  expect_equal(geolibre()$x$panels, "expanded")
   expect_equal(geolibre(layout = "full", theme = "dark")$x$layout, "full")
   expect_equal(geolibre(layout = "full", theme = "dark")$x$theme, "dark")
+  expect_equal(geolibre(panels = "collapsed")$x$panels, "collapsed")
+  expect_equal(geolibre(panels = "hidden")$x$panels, "hidden")
   # The superseded map_only argument still selects the map-only layout.
   expect_equal(geolibre(map_only = TRUE)$x$layout, "maponly")
   expect_error(geolibre(layout = "tiny"), "layout|arg")
   expect_error(geolibre(theme = "sepia"), "theme|arg")
+  expect_error(geolibre(panels = "floating"), "panels|arg")
 })
 
 test_that("a supplied project takes precedence over constructor defaults", {

--- a/vignettes/articles/interactive-map.Rmd
+++ b/vignettes/articles/interactive-map.Rmd
@@ -18,9 +18,10 @@ library(geolibre)
 
 A complete `.geolibre.json` project can be loaded from a URL and passed to
 `geolibre()`. This example opens a 3D map of New York City buildings and subway
-lines.
+lines. The project is fetched while this page is built, so the chunk reports the
+error rather than failing the build if the host is unreachable.
 
-```{r nyc-buildings}
+```{r nyc-buildings, error=TRUE}
 project_url <- "https://assets.geolibre.app/projects/nyc-buildings.geolibre.json"
 nyc_buildings <- jsonlite::read_json(project_url, simplifyVector = FALSE)
 

--- a/vignettes/articles/interactive-map.Rmd
+++ b/vignettes/articles/interactive-map.Rmd
@@ -14,6 +14,19 @@ the live maps requires JavaScript and internet access.
 library(geolibre)
 ```
 
+## Load a GeoLibre project
+
+A complete `.geolibre.json` project can be loaded from a URL and passed to
+`geolibre()`. This example opens a 3D map of New York City buildings and subway
+lines.
+
+```{r nyc-buildings}
+project_url <- "https://assets.geolibre.app/projects/nyc-buildings.geolibre.json"
+nyc_buildings <- jsonlite::read_json(project_url, simplifyVector = FALSE)
+
+geolibre(nyc_buildings, panels = "collapsed")
+```
+
 ## A single point
 
 Style overrides can be passed as named arguments or through a `style` list.


### PR DESCRIPTION
## Summary
- Add a `panels` argument to `geolibre()` accepting `"expanded"`, `"collapsed"`, or `"hidden"`, so embedded maps can give more room to the map itself.
- Pass the value through the widget payload to the embed URL, and include it in the iframe signature so a change re-renders the frame.
- Document the argument and add a pkgdown article example that loads a hosted project with the panels collapsed.

## Test plan
- [x] `testthat::test_local()` passes
- [x] `roxygen2::roxygenise()` produces no documentation drift
- [ ] Rendered article shows the map with side panels collapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `panels` option to control whether side panels start expanded, collapsed, or hidden.
  * Collapsed panels display an icon rail, while hidden panels are removed from view.
  * Panel settings are preserved when loading maps from URLs.

* **Documentation**
  * Updated function documentation with panel configuration details.
  * Added an example for loading and rendering a complete map project with collapsed panels.

* **Bug Fixes**
  * Invalid panel settings are now rejected with validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->