### PR TITLE
Set geolibre map height to 600 pixels

### DIFF
--- a/vignettes/articles/interactive-map.Rmd
+++ b/vignettes/articles/interactive-map.Rmd
@@ -25,7 +25,7 @@ error rather than failing the build if the host is unreachable.
 project_url <- "https://assets.geolibre.app/projects/nyc-buildings.geolibre.json"
 nyc_buildings <- jsonlite::read_json(project_url, simplifyVector = FALSE)
 
-geolibre(nyc_buildings, panels = "collapsed")
+geolibre(nyc_buildings, panels = "collapsed", height = 600)
 ```
 
 ## A single point


### PR DESCRIPTION
Increase the height of the geolibre map to 600 pixels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the embedded map height to 600 pixels in the NYC buildings example for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->