### PR TITLE
docs: make interactive maps full width

### DIFF
--- a/vignettes/articles/interactive-map.Rmd
+++ b/vignettes/articles/interactive-map.Rmd
@@ -3,7 +3,7 @@ title: "Interactive GeoLibre map"
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", out.width = "100%")
 ```
 
 This page runs the same `geolibre` code used in RStudio, Quarto, R Markdown,


### PR DESCRIPTION
## Summary
- render interactive article widgets at the full content width
- align map output width with the corresponding code blocks

## Test plan
- [x] Validate the knitr `out.width` chunk option
- [x] Run `git diff --check`