### PR TITLE
Validate marker coordinates and properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,8 @@ proxy that drives the live map.
 
 ## Bug fixes
 
+- `add_marker()` and named `add_markers()` entries now reject invalid coordinates
+  and properties instead of serializing malformed GeoJSON.
 - `set_view(bbox = )` wrote an unknown `bounds` field that the application
   ignored, so the requested extent was silently dropped. It now resolves the box
   to the `center`, `zoom`, and `bbox` the application reads.

--- a/R/geojson.R
+++ b/R/geojson.R
@@ -152,6 +152,13 @@ read_local_vector <- function(path, source_layer = NULL) {
 }
 
 point_feature <- function(lng, lat, properties = NULL) {
+  if (!is.null(properties)) {
+    if (!is.list(properties) ||
+        (length(properties) &&
+          (is.null(names(properties)) || any(!nzchar(names(properties)))))) {
+      stop_geolibre("`properties` must be NULL or a named list.")
+    }
+  }
   list(
     type = "Feature",
     geometry = list(type = "Point", coordinates = c(as.numeric(lng), as.numeric(lat))),
@@ -202,6 +209,12 @@ points_to_featurecollection <- function(points) {
         stop_geolibre(
           "Entry ", index, " needs longitude (lng/lon/long/longitude/x) and ",
           "latitude (lat/latitude/y) values."
+        )
+      }
+      if (!is_scalar_number(lng) || !is_scalar_number(lat)) {
+        stop_geolibre(
+          "Entry ", index,
+          " longitude and latitude must each be one finite numeric value."
         )
       }
       properties <- entry[setdiff(

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -57,6 +57,33 @@ test_that("marker helpers accept pairs, matrices, and data frames", {
   expect_error(add_markers(geolibre(), list(list(lng = -77))), "latitude")
 })
 
+test_that("named marker entries reject invalid coordinates", {
+  expect_error(
+    add_markers(geolibre(), list(list(lng = "not-a-number", lat = 39))),
+    "finite numeric"
+  )
+  expect_error(
+    add_markers(geolibre(), list(list(lng = -77, lat = Inf))),
+    "finite numeric"
+  )
+  expect_error(
+    add_markers(geolibre(), list(list(lng = c(-77, -76), lat = 39))),
+    "finite numeric"
+  )
+})
+
+test_that("marker properties must be NULL or a named list", {
+  expect_error(add_marker(geolibre(), -77, 39, properties = "DC"), "named list")
+  expect_error(add_marker(geolibre(), -77, 39, properties = list("DC")), "named list")
+
+  marker <- add_marker(
+    geolibre(), -77, 39,
+    properties = list(name = "DC", population = 678972)
+  )
+  properties <- marker$x$project$layers[[1]]$geojson$features[[1]]$properties
+  expect_equal(properties, list(name = "DC", population = 678972))
+})
+
 test_that("marker layers reject non-point geometries", {
   polygon <- list(
     type = "Polygon",


### PR DESCRIPTION
# Validate marker coordinates and properties before building GeoJSON

## Summary

- reject non-numeric, non-finite, and non-scalar coordinates in named `add_markers()` entries;
- require `add_marker(properties = )` values to be `NULL` or a named list;
- add regression tests for invalid coordinates, malformed properties, and valid named properties.

## Root cause

Named marker entries bypassed the numeric validation used for unnamed `c(longitude, latitude)` pairs. `point_feature()` then coerced invalid values with `as.numeric()`, allowing a value such as `"not-a-number"` to become `NA` and serialize as JSON `null`.

`point_feature()` also accepted any `properties` value even though GeoJSON requires `properties` to be an object or `null`. For example, `properties = "DC"` serialized as a JSON string.

## User impact

Invalid marker inputs now fail at construction time with a targeted error instead of producing malformed GeoJSON that can be rejected later by the embedded application. Valid named property lists retain their existing shape.

## Validation

- `devtools::test()`: 408 passed, 0 failed, warned, or skipped
- `devtools::check(document = FALSE, manual = FALSE, cran = FALSE)`: 0 errors,
  0 warnings, 0 notes
