### PR TITLE
docs: widen the pkgdown content area

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^cran-comments\.md$
 ^CNAME$
 ^docs$
+^pkgdown$
 ^vignettes/articles$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -1,0 +1,30 @@
+// Widen the page. pkgdown caps text at 50rem inside a col-md-9 column, so on a
+// wide screen the content stops well short of its column and leaves a band of
+// dead space between it and the right-hand "On this page" sidebar. Interactive
+// map widgets, which render at the full content width, suffer most.
+@media (min-width: 992px) {
+  .container {
+    max-width: 1440px;
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (min-width: 768px) {
+  // Let the content fill its column. min-width: 0 keeps a wide code block or
+  // map widget from expanding the flex item past its column.
+  .row > main {
+    max-width: none;
+    min-width: 0;
+  }
+
+  // pkgdown separates the sidebar from the content with an 80px left margin.
+  // That margin sits outside the 9/3 split, so once main uses its full column
+  // the row overflows and the sidebar wraps below the article. Move the gap
+  // inside the sidebar's own column as padding, which keeps the same visual
+  // separation and puts the sidebar flush against the right edge.
+  .row > aside {
+    margin-left: 0;
+    padding-left: 2.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `pkgdown/extra.scss` so page content fills its `col-md-9` column instead of stopping at pkgdown's 50rem cap, and raise the container to 1440px on large screens. At a 1414px viewport the content goes from 800px to about 1030px wide, which mainly benefits the interactive map widgets that render at the full content width.
- Move the sidebar's 80px left margin inside its own column as padding. That margin sits outside the 9/3 split, so once the content uses its full column the row overflows and the "On this page" sidebar wraps below the article. Same visual gap, and the sidebar now sits flush against the right edge instead of leaving dead space beside it.
- Add `^pkgdown$` to `.Rbuildignore` so the new directory is not bundled into the package tarball.

## Test plan
- [x] Built the site locally (`pkgdown::build_site()`) and confirmed the compiled rules land in the Bootstrap bundle.
- [x] Measured the layout in Chromium at 1920, 1414, 1280, 992, 800, and 500px: content and sidebar stay side by side down to the md breakpoint, stack below it, and no viewport produces horizontal overflow.
- [x] Checked an article page, a reference page, and the home page.
- [ ] Confirm the deployed site at r.geolibre.app after the pkgdown workflow runs on merge.