### PR TITLE
docs: point installation at the CRAN release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # geolibre 0.2.0
 
-This release brings the R API to parity with the GeoLibre Python API. The
-package now covers every layer type the application reads, layer management,
-data-driven symbology, on-map controls, standalone HTML export, and a Shiny
-proxy that drives the live map.
+First CRAN release. This release brings the R API to parity with the GeoLibre
+Python API. The package now covers every layer type the application reads, layer
+management, data-driven symbology, on-map controls, standalone HTML export, and
+a Shiny proxy that drives the live map.
 
 ## New layer types
 
@@ -90,7 +90,7 @@ proxy that drives the live map.
 
 # geolibre 0.1.0
 
-Initial CRAN release.
+Initial release, on GitHub only.
 
 - Add a responsive `htmlwidgets` interface to GeoLibre for RStudio, Quarto,
   R Markdown, and Shiny.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # geolibre
 
+[![CRAN status](https://www.r-pkg.org/badges/version/geolibre)](https://CRAN.R-project.org/package=geolibre)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/geolibre)](https://CRAN.R-project.org/package=geolibre)
 [![R-CMD-check](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml)
 [![GeoLibre](https://img.shields.io/badge/GeoLibre-web-16a34a)](https://web.geolibre.app/)
 
@@ -12,11 +14,16 @@ to try the R widget directly in your browser.
 
 ## Installation
 
-```r
-# Once released on CRAN:
-install.packages("geolibre")
+Install the released version from
+[CRAN](https://CRAN.R-project.org/package=geolibre):
 
-# Development version:
+```r
+install.packages("geolibre")
+```
+
+Or the development version from GitHub:
+
+```r
 install.packages("pak")
 pak::pak("opengeos/geolibre-r")
 ```


### PR DESCRIPTION
`geolibre` 0.2.0 is now on CRAN: https://cran.r-project.org/web/packages/geolibre/index.html

- README installation now leads with `install.packages("geolibre")` from CRAN, with `pak` kept for the development version.
- Added CRAN status and download badges.
- NEWS credited 0.1.0 as the "Initial CRAN release", but 0.1.0 was never submitted (no CRAN archive entry) — 0.2.0 is the first version CRAN published. Fixed both headings.

https://claude.ai/code/session_01BRUGY3CqphbC1FNhkZJKBt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes to identify version 0.2.0 as the first CRAN release.
  - Clarified that the R API now matches the GeoLibre Python API.
  - Corrected the 0.1.0 release description to reflect its GitHub-only availability.
  - Added CRAN status and download badges to the README.
  - Updated installation instructions for both the released and development versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->